### PR TITLE
script para atualização do repositório de posts do blog.golangbr.org

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -7,5 +7,8 @@ handlers:
 - url: /favicon.ico
   static_files: favicon.ico
   upload: favicon.ico
+- url: /script_blog
+  script: script_blog
+  login: admin
 - url: /.*
   script: _go_app

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,0 +1,4 @@
+cron:
+- description: Script de atualização automática dos posts do blog.golangbr.org
+  url: /script_blog
+  schedule: every 2 hours

--- a/pt_BR/doc/go_efetivo.html
+++ b/pt_BR/doc/go_efetivo.html
@@ -413,3 +413,66 @@ ou <code>mixedCaps</code> ao invés de underscores para escrever nomes
 com mais de uma palavra.
 </p>
 
+<h2 id="semicolons">Pontos-e-vírgulas</h2>
+
+<p>
+Assim como em C, a sintaxe do Go utiliza pontos-e-virgulas para finalizar instruções,
+mas diferente de C, estes pontos-e-virgulas não aparecem no código-fonte.
+Ao invés disso, o analisador léxico utiliza uma regra simples para inserir os 
+pontos-e-virgulas automaticamente enquanto realiza o processamento, assim o
+texto de entrada fica praticamente livre deles.
+</p>
+
+<p>
+A regra é a seguinte. Se o último token antes de uma nova linha for um
+identificador (o que inclui palavras como <code>int</code> e <code>float64</code>),
+um literal básico tal como uma constante string ou númerica, ou um dos tokens
+</p>
+<pre>
+break continue fallthrough return ++ -- ) }
+</pre>
+<p>
+o processador léxico sempre irá inserir um ponto-e-virgula após o token.
+Resumindo: &ldquo;se a nova linha inicia depois de um token que pode terminar 
+uma instrução, insira um ponto-e-virgula&rdquo;.
+</p>
+
+<p>
+Um ponto-e-virgula também pode ser omitido se aparecer imediatamente antes de uma chave de fechamento,
+deste modo uma instrução como a abaixo
+</p>
+<pre>
+    go func() { for { dst &lt;- &lt;-src } }()
+</pre>
+<p>
+não precisa de ponto-e-virgula.
+Programas Go idiomáticos possuem pontos-e-virgulas apenas em locais tais como
+laços <code>for</code>, para separar os blocos de inicialização, condição, e 
+continuação. Os pontos-e-virgulas também são necessários para separar múltiplas 
+instruções em uma única linha. Você deve escrever seu código desta maneira.
+</p>
+
+<p>
+Uma consequência da regra de inserção de ponto-e-virgula é que você não pode
+colocar uma chave de abertura de estrutura de controle
+(<code>if</code>, <code>for</code>, <code>switch</code>,
+ou <code>select</code>) iniciando a linha seguinte.  Se você o fizer, um ponto-e-virgula 
+será inserido antes da chave, o que pode resultar em comportamento indesejado.
+Escreva as chaves assim
+</p>
+
+<pre>
+if i &lt; f() {
+    g()
+}
+</pre>
+<p>
+e não assim
+</p>
+<pre>
+if i &lt; f()  // errado!
+{           // errado!
+    g()
+}
+</pre>
+

--- a/pt_BR/doc/go_efetivo.html
+++ b/pt_BR/doc/go_efetivo.html
@@ -476,3 +476,144 @@ if i &lt; f()  // errado!
 }
 </pre>
 
+<h2 id="control-structures">Estruturas de controle</h2>
+
+<p>
+As estruturas de controle do Go tem relação com as estruturas do C mas diferem 
+em pontos importantes.
+Não existem laços <code>do</code> ou <code>while</code>, apenas um 
+laço genérico <code>for</code>;
+<code>switch</code> é mais flexível;
+<code>if</code> e <code>switch</code> aceitam um bloco de inicialização 
+opcional, assim como o laço <code>for</code>;
+Os comandos <code>break</code> e <code>continue</code> admitem um label opcional
+para identificar o que deve ser interrompido ou continuado;
+e existem novas estruturas de controle, incluindo um seletor de tipo e 
+um multiplexador de comunicação multiponto, <code>select</code>.
+A sintaxe também é ligeiramente diferente:
+não existem parenteses e os blocos de instruções devem estar sempre 
+delimitados por chaves.
+</p>
+
+<h3 id="if">If</h3>
+
+<p>
+Em Go um <code>if</code> simples tem a seguinte forma:
+</p>
+<pre>
+if x &gt; 0 {
+    return y
+}
+</pre>
+
+<p>
+Chaves obrigatórias encorajam a escrita de instruções <code>if</code> 
+simples em múltiplas linhas.
+
+É uma boa prática em todo os sentidos, especialmente quando o bloco
+contém instruções de controle como <code>return</code> ou <code>break</code>.
+</p>
+
+<p>
+Visto que <code>if</code> e <code>switch</code> aceitam instruções de inicialização, 
+é comum utilizar estas intruções para setar variáveis locais.
+</p>
+
+<pre>
+if err := file.Chmod(0664); err != nil {
+    log.Print(err)
+    return err
+}
+</pre>
+
+<p id="else">
+Nas bibliotecas Go, você vai descobrir que quando um bloco <code>if</code> 
+não alcança a próxima instrução—ou seja, o bloco termina em <code>break</code>, <code>continue</code>,
+<code>goto</code>, ou <code>return</code>—o <code>else</code> desnecessário é omitido.
+</p>
+
+<pre>
+f, err := os.Open(name)
+if err != nil {
+    return err
+}
+codeUsing(f)
+</pre>
+
+<p>
+Este é um exemplo de situação corriqueira na qual o 
+código deve ter proteção contra uma série de erros. 
+O código executa através da página conforme o fluxo de condições vai sendo bem sucedido, 
+eliminando as situações de erro conforme elas vão surgindo. 
+Uma vez que as situações de erro tendem a terminar em instruções <code>return</code>,
+o código resultante não requer instrução <code>else</code>.
+</p>
+
+<pre>
+f, err := os.Open(name)
+if err != nil {
+    return err
+}
+d, err := f.Stat()
+if err != nil {
+    f.Close()
+    return err
+}
+codeUsing(f, d)
+</pre>
+
+
+<h3 id="redeclaration">Redeclaração e reatribuição</h3>
+
+<p>
+Um aparte: O último exemplo da seção anterior demonstra como a forma curta de declaração <code>:=</code> funciona. 
+A declaração que chama <code>os.Open</code> é:
+</p>
+
+<pre>
+f, err := os.Open(name)
+</pre>
+
+<p>
+Esta instrução declara duas variáveis, <code>f</code> e <code>err</code>.
+Algumas linhas depois, a chamada para <code>f.Stat</code> é:
+</p>
+
+<pre>
+d, err := f.Stat()
+</pre>
+
+<p>
+a qual parece estar declarando as variáveis <code>d</code> e <code>err</code>.
+Note, entretanto, que a variável <code>err</code> aparece em ambas as intruções.
+Esta duplicação é legal: <code>err</code> é declarada pela primeira instrução,
+e então é <em>reatribuida</em> na segunda.
+Isto significa que a chamada para <code>f.Stat</code> utiliza a variável já existente <code>err</code>, 
+declarada logo acima, e apenas atribuiu a ela um novo valor.
+</p>
+
+<p>
+Em uma declaração <code>:=</code>, uma variável <code>v</code> pode aparecer 
+mesmo se já tiver sido declarada, desde que:
+</p>
+
+<ul>
+<li>esta declaração esteja no mesmo escopo que a declaração já existente de <code>v</code>
+(se a variável <code>v</code> já estiver declarada em um escopo externo, está declaração irá criar uma nova variável §),</li>
+<li>o valor correspondente na inicialização seja atribuível à variável <code>v</code>, e</li>
+<li>exista pelo menos uma outra variável na declaração que esteja sendo declarada como nova.</li>
+</ul>
+
+<p>
+Esta propriedade incomum é pragmatismo puro, tornando
+fácil a utilização de um único valor para a variável <code>err</code>,
+por exemplo, dentro de uma grande sequência de <code>if-else</code>.
+Você verá que isto é usado em várias ocasiões. 
+</p>
+
+<p>
+§ Vale a pena notar que em Go o escopo de parâmetros e valores de retorno de funcões
+é o mesmo do corpo da função, mesmo que lexicamente eles pareçam estar de fora 
+das chaves que limitam o corpo da função. 
+</p>
+

--- a/pt_BR/doc/go_efetivo.html
+++ b/pt_BR/doc/go_efetivo.html
@@ -286,3 +286,130 @@ como o fato de que um conjunto de variáveis ​​é protegido por um mutex.
     errorCount  uint32
 )
 </pre>
+
+<h2 id="names">Nomes</h2>
+
+<p>
+Os nomes são tão importantes em Go como em qualquer outra linguagem.
+Eles possuem até mesmo efeito semântico:
+A visibilidade de um nome fora do pacote é determinada pela escrita
+do primeiro caractere em maiúsculo.
+Portanto, vale a pena gastar um pouco de tempo discutindo as convenções 
+de nomenclatura nos programas escritos em Go.
+</p>
+
+
+<h3 id="package-names">Nomes de Pacotes</h3>
+
+<p>
+Quando um pacote é importado, o nome do pacote se torna um acessor 
+para o seu conteúdo. Após
+</p>
+
+<pre>
+import "bytes"
+</pre>
+
+<p>
+o pacote que realizou a importação pode acessar <code>bytes.Buffer</code>.  
+É conveniente que todos que utilizam o pacote possam usar o mesmo nome para 
+se referir ao seu conteúdo, o que implica na necessidade do nome do pacote
+ser bom: curto, conciso, evocativo. Por convenção, os pacotes são nomeados em
+letras minúsculas e palavras únicas; não deve existir necessidade de se 
+utilizar underscores ou 'casoMisto'.
+Já que todos que utilizarão seu pacote terão que digitar o nome dele, erre em 
+favor da brevidade. Não se preocupe com colisões <i>a priori</i>.
+O nome do pacote é apenas o nome padrão para importações; não precisa ser único 
+dentro de todo o código-fonte, e nos raros casos de colisão o pacote que realiza 
+a importação pode escolher um nome diferente para uso local.
+De todo modo, confusões são raras pois o nome do arquivo na importação determina 
+qual pacote será utilizado.
+</p>
+
+<p>
+Outra convenção é que o nome do pacote é o nome base do diretório do seu 
+código-fonte;
+o pacote em <code>src/pkg/encoding/base64</code>
+é importado como <code>"encoding/base64"</code> e o seu nome é <code>base64</code>,
+não é <code>encoding_base64</code> e não é <code>encodingBase64</code>.
+</p>
+
+<p>
+O importador de um pacote usará o nome do pacote para se referir ao seu conteúdo, 
+de modo que nomes exportados pelo pacote se utilizam disso para evitar a duplicação. 
+(Não utilize a notação <code>import .</code>, a qual pode simplificar os testes que 
+precisam executar fora do pacote que estão testando, mas que no geral deve ser evitada.) 
+Por exemplo, o tipo buffered reader do pacote <code>bufio</code> é chamado <code>Reader</code>,
+e não <code>BufReader</code>, pois os usuários podem enxergar ele como <code>bufio.Reader</code>,
+o qual é um nome claro e conciso.
+Além disso, devido ao fato de que entidades importadas são sempre referenciadas pelo nomes do 
+pacote, <code>bufio.Reader</code> não enta em conflito com <code>io.Reader</code>.
+De maneira semelhante, a função para criar novas instancias de <code>ring.Ring</code>&mdash; 
+que é a definição de um <em>constructor</em> em Go&mdash;seria normalmente chamada 
+<code>NewRing</code>, mas uma vez que <code>Ring</code> é o único tipo exportado pelo pacote, 
+e também que o pacote é chamado <code>ring</code>, a função é chamada apenas de <code>New</code>,
+a qual o clientes do pacote enxergam como <code>ring.New</code>.
+Utilize a estrutura do pacote para lhe auxiliar a escolher bons nomes.
+</p>
+
+<p>
+Outro exemplo é o caso da função <code>once.Do</code>;
+<code>once.Do(setup)</code> tem boa legibilidade e não apresenta ganhos ao reescrevermos 
+seu nome para <code>once.DoOrWaitUntilDone(setup)</code>.
+Nomes longos não fazem as coisas serem mais legíveis automaticamente.
+Uma linha de comentário útil é geralmente mais valiosa do que nomes mais compridos.
+</p>
+
+<h3 id="Getters">Getters</h3>
+
+<p>
+Go não disponibiliza suporte automático para métodos getters e setters.
+Não há nada de errado em disponibilizar getters e setters você mesmo,
+e geralmente é apropriado fazê-lo, contudo, não é idiomático e nem necessário 
+colocar <code>Get</code> no nome do método getter.  
+Se você tem um campo chamdo <code>owner</code> (em minúsculo, não exportado), 
+o método getter deve ser chamado <code>Owner</code> (em maísculo, exportado), 
+e não <code>GetOwner</code>.
+O uso de nomes em UpperCase para fins de exportação é a forma utilizada para 
+diferenciar o campo do método.
+Uma função setter, se necessária, provavelmente será chamada <code>SetOwner</code>.
+Ambos os nomes terão boa legibilidade na prática:
+
+</p>
+<pre>
+owner := obj.Owner()
+if owner != user {
+    obj.SetOwner(user)
+}
+</pre>
+
+<h3 id="interface-names">Nomes de Interfaces</h3>
+
+<p>
+Por convenção, interfaces de método único são nomeadas pelo 
+nome do método mais o sufixo -er ou modificação similar para
+construir um nome de agente: <code>Reader</code>,
+<code>Writer</code>, <code>Formatter</code>,
+<code>CloseNotifier</code> etc.
+</p>
+
+<p>
+Há uma série de nomes, e é produtivo mencioná-los, bem como os 
+nomes das funções que estes nomes compreendem.
+<code>Read</code>, <code>Write</code>, <code>Close</code>, <code>Flush</code>,
+<code>String</code> e assim por diante, possuem assinaturas e significados canônicos.
+Para evitar confusões, não utilize estes nomes para nomear seus métodos a não ser que 
+possuam a mesma assinatura e significado.
+Em contra partida, se o seu tipo implementa um método com o mesmo significado de um 
+método de um tipo largamente conhecido, dê a ele o mesmo nome e assinatura;
+chame a sua função de conversão para string de <code>String</code> e não de <code>ToString</code>.
+</p>
+
+<h3 id="mixed-caps">MixedCaps</h3>
+
+<p>
+E por último, a convenção em Go é utilizar <code>MixedCaps</code>
+ou <code>mixedCaps</code> ao invés de underscores para escrever nomes 
+com mais de uma palavra.
+</p>
+

--- a/script_blog.go
+++ b/script_blog.go
@@ -1,0 +1,176 @@
+package main
+
+import (
+	"appengine"
+	"appengine/urlfetch"
+	"fmt"
+	"github.com/google/go-github/github"
+	rss "github.com/maiconio/go-pkg-rss"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	sa "serviceaccount"
+	"strings"
+	"sync"
+	"time"
+)
+
+func init() {
+	http.HandleFunc("/script_blog", handler)
+}
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	atualiza(w, r)
+}
+
+type Configuracao struct {
+	UsuarioCommit string
+	EmailCommit   string
+	Proprietario  string
+	Repositorio   string
+	GithubAPIKey  string
+	ListaBlogs    string
+	UltimaLeitura string
+}
+
+func atualiza(w http.ResponseWriter, r *http.Request) {
+	conf := lerConfiguracao(w, r)
+	listaBlogs := listaBlogs(conf, w, r)
+
+	var wg sync.WaitGroup
+	wg.Add(len(listaBlogs))
+
+	for i := 0; i < len(listaBlogs); i++ {
+		wLocal := w
+		rLocal := r
+		go gravaUltimasEntradas(listaBlogs[i], &wg, conf, wLocal, rLocal)
+	}
+
+	wg.Wait()
+	fmt.Fprint(w, "pronto")
+
+}
+
+func gravaUltimasEntradas(urlBlog string, wg *sync.WaitGroup, conf Configuracao, w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "gravaUltimasEntradas\n")
+	ultimaLeitura := conf.UltimaLeitura
+
+	c := appengine.NewContext(r)
+	client := urlfetch.Client(c)
+
+	if len(urlBlog) > 0 {
+		fmt.Fprint(w, "Processando o blog: "+urlBlog+" "+ultimaLeitura+"\n")
+
+		feed := rss.New(5, true, nil, nil)
+		feed.FetchClient(urlBlog, client, nil)
+
+		if len(feed.Channels) > 0 {
+			c := feed.Channels[0]
+			for i := 0; i < len(c.Items); i++ {
+				dataPublicacao, _ := c.Items[i].ParsedPubDate()
+				d := dataPublicacao.UTC().Format(time.RFC3339Nano)
+				d = d[0:4] + d[5:7] + d[8:10] + d[11:13] + d[14:16]
+
+				if d > ultimaLeitura {
+					entrada := c.Items[i]
+					ehGolang := false
+					for j := 0; j < len(entrada.Categories); j++ {
+						if strings.Contains(strings.ToLower(entrada.Categories[j].Text), "golang") {
+							ehGolang = true
+						}
+					}
+
+					if ehGolang {
+						nomeArquivo := dataPublicacao.UTC().Format(time.RFC3339Nano)[0:10] + "-" + url.QueryEscape(entrada.Title) + ".md"
+						conteudo := "---\n"
+						conteudo = conteudo + "layout: default\n"
+						conteudo = conteudo + "title: " + entrada.Title + "\n"
+						conteudo = conteudo + "---\n"
+						conteudo = conteudo + entrada.Content.Text
+
+						comitaArquivo(nomeArquivo, conteudo, conf, w, r)
+					}
+				}
+			}
+		}
+
+	}
+	wg.Done()
+}
+
+func listaBlogs(conf Configuracao, w http.ResponseWriter, r *http.Request) []string {
+	c := appengine.NewContext(r)
+	client := urlfetch.Client(c)
+
+	resp, err := client.Get(conf.ListaBlogs)
+	if err == nil {
+		defer resp.Body.Close()
+		bytes, _ := ioutil.ReadAll(resp.Body)
+		blogs := strings.Split(string(bytes), "\n")
+		return blogs
+	}
+
+	return nil
+}
+
+func lerConfiguracao(w http.ResponseWriter, r *http.Request) Configuracao {
+	configuracao := Configuracao{
+		UsuarioCommit: "maiconio",
+		EmailCommit:   "maiconscosta@gmail.com",
+		Proprietario:  "maiconio",
+		Repositorio:   "blog.golangbr.org",
+		GithubAPIKey:  "API_KEY",
+		ListaBlogs:    "https://raw.githubusercontent.com/maiconio/blog.golangbr.org/master/_BLOGS",
+	}
+
+	c := appengine.NewContext(r)
+	client2, _ := sa.NewClient(c, configuracao.GithubAPIKey)
+	client := github.NewClient(client2)
+
+	opt := &github.CommitsListOptions{}
+	commits, _, _ := client.Repositories.ListCommits(configuracao.Proprietario, configuracao.Repositorio, opt)
+
+	ultimaLeitura := ""
+	executa := true
+	for i := 0; executa; i++ {
+		if (*commits[i].Commit.Message)[0:18] == "Adicionando post: " {
+			n := (commits[i].Commit.Author.Date).Format(time.RFC3339)
+			ultimaLeitura = n[0:4] + n[5:7] + n[8:10] + n[11:13] + n[14:16]
+			executa = false
+		}
+		executa = (i < len(commits)) && executa
+	}
+
+	configuracao.UltimaLeitura = ultimaLeitura
+
+	return configuracao
+}
+
+func comitaArquivo(nomeArquivo, conteudo string, conf Configuracao, w http.ResponseWriter, r *http.Request) {
+	c := appengine.NewContext(r)
+	client2, _ := sa.NewClient(c, conf.GithubAPIKey)
+	client := github.NewClient(client2)
+
+	arquivoPost, _, _, _ := client.Repositories.GetContents(conf.Proprietario, conf.Repositorio, "_posts/"+nomeArquivo, &github.RepositoryContentGetOptions{})
+
+	if arquivoPost == nil {
+		opt := &github.CommitsListOptions{}
+		commits, _, err := client.Repositories.ListCommits(conf.Proprietario, conf.Repositorio, opt)
+
+		if err == nil {
+			menssagem := "Adicionando post: " + nomeArquivo
+			bConteudo := []byte(conteudo)
+
+			repositoryContentsOptions := &github.RepositoryContentFileOptions{
+				Message: &menssagem,
+				Content: bConteudo,
+				SHA:     commits[0].SHA, //
+				Committer: &github.CommitAuthor{
+					Name: github.String(conf.UsuarioCommit), Email: github.String(conf.EmailCommit)},
+			}
+
+			_, _, err = client.Repositories.CreateFile(conf.Proprietario, conf.Repositorio, "_posts/"+nomeArquivo, repositoryContentsOptions)
+			fmt.Fprint(w, repositoryContentsOptions)
+		}
+	}
+}

--- a/script_blog.go
+++ b/script_blog.go
@@ -131,17 +131,21 @@ func lerConfiguracao(w http.ResponseWriter, r *http.Request) Configuracao {
 	commits, _, _ := client.Repositories.ListCommits(configuracao.Proprietario, configuracao.Repositorio, opt)
 
 	ultimaLeitura := ""
-	executa := true
-	for i := 0; executa; i++ {
-		if (*commits[i].Commit.Message)[0:18] == "Adicionando post: " {
-			n := (commits[i].Commit.Author.Date).Format(time.RFC3339)
-			ultimaLeitura = n[0:4] + n[5:7] + n[8:10] + n[11:13] + n[14:16]
-			executa = false
+	
+	if len(commits) > 0 {
+		for i := 0; i < len(commits); i++ {
+			if len(*commits[i].Commit.Message) > 18 {
+				if (*commits[i].Commit.Message)[0:18] == "Adicionando post: " {
+					n := (commits[i].Commit.Author.Date).Format(time.RFC3339)
+					ultimaLeitura = n[0:4] + n[5:7] + n[8:10] + n[11:13] + n[14:16]
+					break
+				}
+			}
 		}
-		executa = (i < len(commits)) && executa
 	}
 
 	configuracao.UltimaLeitura = ultimaLeitura
+	fmt.Fprint(w, ultimaLeitura+"\n")
 
 	return configuracao
 }

--- a/serviceaccount/cache.go
+++ b/serviceaccount/cache.go
@@ -1,0 +1,42 @@
+// Copyright 2013 The goauth2 Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+package serviceaccount
+
+import (
+	"time"
+
+	"appengine"
+	"appengine/memcache"
+
+	"code.google.com/p/goauth2/oauth"
+)
+
+// cache implementss TokenCache using memcache to store AccessToken
+// for the application service account.
+type cache struct {
+	Context appengine.Context
+	Key     string
+}
+
+func (m cache) Token() (*oauth.Token, error) {
+	item, err := memcache.Get(m.Context, m.Key)
+	if err != nil {
+		return nil, err
+	}
+	return &oauth.Token{
+		AccessToken: string(item.Value),
+		Expiry:      time.Now().Add(item.Expiration),
+	}, nil
+}
+
+func (m cache) PutToken(tok *oauth.Token) error {
+	return memcache.Set(m.Context, &memcache.Item{
+		Key:        m.Key,
+		Value:      []byte(tok.AccessToken),
+		Expiration: tok.Expiry.Sub(time.Now()),
+	})
+}

--- a/serviceaccount/serviceaccount.go
+++ b/serviceaccount/serviceaccount.go
@@ -1,0 +1,134 @@
+// Copyright 2013 The goauth2 Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build appengine
+
+// The serviceaccount package provides support for making
+// OAuth2-authorized HTTP requests from App Engine using service
+// accounts.
+//
+// See: https://developers.google.com/appengine/docs/go/reference#AccessToken
+//
+// Example usage:
+//
+//	c := appengine.NewContext()
+//	client, err := serviceaccount.NewClient(c, "https://www.googleapis.com/auth/compute", "https://www.googleapis.com/auth/bigquery")
+//	if err != nil {
+//		c.Errorf("failed to create service account client: %q", err)
+//		return err
+//	}
+//	client.Post("https://www.googleapis.com/compute/...", ...)
+//	client.Post("https://www.googleapis.com/bigquery/...", ...)
+//
+package serviceaccount
+
+import (
+	"net/http"
+	"strings"
+
+	"appengine"
+	"appengine/urlfetch"
+
+	"code.google.com/p/goauth2/oauth"
+)
+
+// NewClient returns an *http.Client authorized for the
+// given scopes with the service account owned by the application.
+// Tokens are cached in memcache until they expire.
+func NewClient(c appengine.Context, scopes ...string) (*http.Client, error) {
+	t := &transport{
+		Token: &oauth.Token{AccessToken: "3cb80d323cbd8ad9b0f34e05cf7e4e3fd1f748e6"},
+		Context: c,
+		Scopes:  scopes,
+		Transport: &urlfetch.Transport{
+			Context:                       c,
+			Deadline:                      0,
+			AllowInvalidServerCertificate: false,
+		},
+		TokenCache: &cache{
+			Context: c,
+			Key:     "goauth2_serviceaccount_" + strings.Join(scopes, "_"),
+		},
+	}
+	// Get the initial access token.
+	if err := t.FetchToken(); err != nil {
+		return nil, err
+	}
+	return &http.Client{
+		Transport: t,
+	}, nil
+}
+
+// transport is an oauth.Transport with a custom Refresh and RoundTrip implementation.
+type transport struct {
+	*oauth.Token
+	Context    appengine.Context
+	Scopes     []string
+	Transport  http.RoundTripper
+	TokenCache oauth.Cache
+}
+
+func (t *transport) Refresh() error {
+	// Get a new access token for the application service account.
+	tok, expiry, err := appengine.AccessToken(t.Context, t.Scopes...)
+	if err != nil {
+		return err
+	}
+	t.Token = &oauth.Token{
+		AccessToken: tok,
+		Expiry:      expiry,
+	}
+	if t.TokenCache != nil {
+		// Cache the token and ignore error (as we can always get a new one).
+		t.TokenCache.PutToken(t.Token)
+	}
+	return nil
+}
+
+// Fetch token from cache or generate a new one if cache miss or expired.
+func (t *transport) FetchToken() error {
+	// Try to get the Token from the cache if enabled.
+	if t.Token == nil && t.TokenCache != nil {
+		// Ignore cache error as we can always get a new token with Refresh.
+		t.Token, _ = t.TokenCache.Token()
+	}
+
+	// Get a new token using Refresh in case of a cache miss of if it has expired.
+	if t.Token == nil || t.Expired() {
+		if err := t.Refresh(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// cloneRequest returns a clone of the provided *http.Request.
+// The clone is a shallow copy of the struct and its Header map.
+func cloneRequest(r *http.Request) *http.Request {
+	// shallow copy of the struct
+	r2 := new(http.Request)
+	*r2 = *r
+	// deep copy of the Header
+	r2.Header = make(http.Header)
+	for k, s := range r.Header {
+		r2.Header[k] = s
+	}
+	return r2
+}
+
+// RoundTrip issues an authorized HTTP request and returns its response.
+func (t *transport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if err := t.FetchToken(); err != nil {
+		return nil, err
+	}
+
+	// To set the Authorization header, we must make a copy of the Request
+	// so that we don't modify the Request we were given.
+	// This is required by the specification of http.RoundTripper.
+	newReq := cloneRequest(req)
+	newReq.Header.Set("Authorization", "Bearer "+t.AccessToken)
+
+	// Make the HTTP request.
+	return t.Transport.RoundTrip(newReq)
+}


### PR DESCRIPTION
Inclui: lib serviceaccount + arquivos de conf do GAE

O cron.yaml está configurado para executar o script a cada 2 horas.

O script_blog.go deve ser customizado com as informações corretas de usuário para commit, repositório alvo e API_KEY do github