### PR TITLE
Feat: Tradução do Go Code of Conduct #14

### DIFF
--- a/CONTRIBUIDORES
+++ b/CONTRIBUIDORES
@@ -6,3 +6,4 @@ Ricardo de Deus dos Santos Correia <rdscorreia@gmail.com>
 Flavio Andrade <flaviochess@gmail.com>
 Mateus Inocêncio Maia <mateusinocenciomaia@gmail.com>
 Davi Marcondes Moreira <davi.marcondes.moreira@gmail.com>
+Gustavo Kennedy Renkel <renkelkennedy@gmail.com>

--- a/pt_BR/doc/conduta.html
+++ b/pt_BR/doc/conduta.html
@@ -1,0 +1,63 @@
+<!--{
+	"Title": "Código de Conduta do Go",
+	"Path": "/conduta/"
+}-->
+
+<h1>Código de Conduta do Go</h1>
+
+<p>O Go é um projeto de código aberto e estamos comprometidos em criar uma comunidade aberta, acolhedora e respeitosa para todos os participantes. Esperamos que todos sigam este código de conduta para manter um ambiente amigável e produtivo.</p>
+
+<h2>Valores Gopher</h2>
+<p>Esses são os valores aos quais as pessoas na comunidade Go (“Gophers”) devem se atentar:</p>
+<ul>
+  <li><strong>Seja amigável e acolhedor.</strong></li>
+  <li><strong>Ser paciente.</strong></li>
+  <li><strong>Lembre-se de que as pessoas têm estilos de comunicação variados e que nem todos estão usando sua língua nativa.</strong></li>
+  <li><strong>Seja atencioso.</strong></li>
+  <li><strong>Seja respeitoso.</strong> Em especial, respeite as diferenças de opinião.</li>
+  <li><strong>Seja caridoso.</strong> Interprete os argumentos dos outros de boa fé.</li>
+  <li><strong>Seja construtivo.</strong> Evite críticas não construtivas.</li>
+  <li><strong>Evite comentários sarcásticos.</strong></li>
+  <li><strong>Evite discussões sobre questões potencialmente ofensivas ou delicadas.</strong></li>
+  <li><strong>Evite microagressões.</strong></li>
+  <li><strong>Seja responsável.</strong> Assuma a responsabilidade por suas palavras e ações.</li>
+</ul>
+
+<h2>Código de Conduta</h2>
+
+<h3>Nosso Compromisso</h3>
+<p>Com o objetivo de promover um ambiente aberto e acolhedor, nos comprometemos a tornar a participação em nosso projeto e comunidade uma experiência livre de assédio para todos, independentemente de idade, tamanho corporal, deficiência, etnia, identidade de gênero, nível de experiência, educação, status socioeconômico, nacionalidade, aparência pessoal, raça, religião ou identidade e orientação sexual.</p>
+
+<h3>Nossos Padrões</h3>
+<p>Exemplos de comportamento que contribuem para a criação de um ambiente positivo incluem:</p>
+<ul>
+  <li>Usar uma linguagem acolhedora e inclusiva.</li>
+  <li>Ser respeitoso com os diferentes pontos de vista e experiências.</li>
+  <li>Aceitar graciosamente críticas construtivas.</li>
+  <li>Focar no que é melhor para a comunidade.</li>
+  <li>Demonstrar empatia para com outros membros da comunidade.</li>
+</ul>
+
+<p>Exemplos de comportamento inaceitável incluem:</p>
+<ul>
+  <li>Uso de linguagem ou imagens sexualizadas e atenção ou avanços sexuais indesejados.</li>
+  <li>Trolling, comentários insultuosos e ataques pessoais ou políticos.</li>
+  <li>Assédio público ou privado.</li>
+  <li>Publicar informações privadas de terceiros sem permissão explícita.</li>
+  <li>Outra conduta que poderia ser considerada inapropriada em um ambiente profissional.</li>
+</ul>
+
+<h3>Nossas responsabilidades</h3>
+<p>Os mantenedores do projeto são responsáveis por esclarecer os padrões de comportamento aceitável e tomar medidas corretivas apropriadas em resposta a quaisquer instâncias de comportamento inaceitável.</p>
+
+<h3>Escopo</h3>
+<p>Este Código de Conduta se aplica tanto em espaços de projeto quanto em espaços públicos quando um indivíduo está representando o projeto ou sua comunidade.</p>
+
+<h3>Resolução de conflitos</h3>
+<p>Se você perceber alguém violando o código de conduta, você é encorajado a abordar o comportamento diretamente. Caso não consiga resolver, denuncie para <a href="mailto:conduct@golang.org">conduct@golang.org</a>.</p>
+
+<h3>Atribuição</h3>
+<p>Este Código de Conduta é uma adaptação do Contributor Covenant, versão 1.4, disponível em <a href="https://www.contributor-covenant.org/version/1/4/code-of-conduct.html">aqui</a>.</p>
+
+<h3>Resumo</h3>
+<p>Trate todos com respeito e gentileza. Seja cuidadoso na forma como você se comunica. Não seja destrutivo ou inflamatório. Se encontrar algum problema, envie um e-mail para <a href="mailto:conduct@golang.org">conduct@golang.org</a>.</p>

--- a/pt_BR/doc/contribua.html
+++ b/pt_BR/doc/contribua.html
@@ -87,7 +87,9 @@ em nosso <a href="http://code.google.com/p/go/issues">tracker de issues</a>.
 
 <p>
 Nos orgulhamos de ser meticulosos; nenhum pedido é muito pequeno.
-
+</p>
+<p>
+	Problemas relacionados à comunidade devem ser relatados para conduct@golang.org. Veja o <a href="/doc/conduta.html">Código de Conduta</a> para mais detalhes.
 </p>
 
 <h3><a href="/doc/contribute.html">Contribuindo com o código</a></h3>


### PR DESCRIPTION
PR para [Issue #14  Tradução do Go Code of Conduct](https://github.com/golangbr/golangbr.org/issues/14).

- Criado página de conduta - traduzida de https://go.dev/conduct.
- Adicionado referência em contribua,html (/projeto) para o Código de Conduta.
- Adicionado novo nome em Contribuidores.

Por favor, revisar tradução, validar o código e testar.